### PR TITLE
AS-3 | warning: [antd: Tooltip] destroyTooltipOnHide

### DIFF
--- a/src/lib/components/Button/base.jsx
+++ b/src/lib/components/Button/base.jsx
@@ -117,7 +117,7 @@ const Button = forwardRef(
     }
 
     return (
-      <Tooltip {...tooltip} size="small" destroyTooltipOnHide={true} keepParent={false}>
+      <Tooltip {...tooltip} size="small" destroyTooltipOnHide>
         {btn}
       </Tooltip>
     )

--- a/src/lib/components/Tooltip.jsx
+++ b/src/lib/components/Tooltip.jsx
@@ -11,7 +11,7 @@ const Tooltip = ({ children, size, overlayStyle: overlayStyleProp, ...otherProps
   }
 
   return (
-    <AntdTooltip destroyTooltipOnHide={{ keepParent: false }} overlayStyle={overlayStyle} {...otherProps}>
+    <AntdTooltip overlayStyle={overlayStyle} {...otherProps}>
       {children}
     </AntdTooltip>
   )


### PR DESCRIPTION
task: https://sosup.atlassian.net/jira/software/projects/AS/boards/12?selectedIssue=AS-3

- Warning fix: destroyTooltipOnHide no need config keepParent anymore. Please use boolean value directly.