### PR TITLE
AS-6 | warning: [antd: Select] dropdownMatchSelectWidth

### DIFF
--- a/src/lib/components/Select/index.jsx
+++ b/src/lib/components/Select/index.jsx
@@ -28,7 +28,7 @@ const Select = ({
   const selectComponent = (
     <AntdSelect
       value={currentValue}
-      dropdownMatchSelectWidth={false}
+      popupMatchSelectWidth={false}
       dropdownStyle={{ zIndex: '6', ...dropdownStyle }}
       options={options}
       {...rest}


### PR DESCRIPTION
task: https://sosup.atlassian.net/jira/software/projects/AS/boards/12?selectedIssue=AS-6

- Warning fix: dropdownMatchSelectWidth is deprecated. Please use popupMatchSelectWidth instead.